### PR TITLE
Use int, not long, as indices in Store.

### DIFF
--- a/src/main/java/analyticalengine/DefaultAnalyticalEngine.java
+++ b/src/main/java/analyticalengine/DefaultAnalyticalEngine.java
@@ -376,9 +376,9 @@ public class DefaultAnalyticalEngine implements AnalyticalEngine {
      *             if the card is not a memory access card.
      */
     private void handleMemoryAccess(final Card card) throws BadCard {
-        long address;
+        int address;
         try {
-            address = Long.parseLong(card.argument(0));
+            address = Integer.parseInt(card.argument(0));
         } catch (NumberFormatException e) {
             throw new BadCard("Illegal number format", card, e);
         }

--- a/src/main/java/analyticalengine/components/HashMapStore.java
+++ b/src/main/java/analyticalengine/components/HashMapStore.java
@@ -50,7 +50,7 @@ public class HashMapStore implements Store {
     public static final BigInteger MIN_VALUE = MAX_VALUE.negate();
 
     /** The hash map that provides the addressable, random-access storage. */
-    private final DefaultHashMap<Long, BigInteger> rack = new DefaultHashMap<Long, BigInteger>();
+    private final DefaultHashMap<Integer, BigInteger> rack = new DefaultHashMap<Integer, BigInteger>();
 
     /**
      * Instantiates this object and initializes the underlying hash map.
@@ -70,7 +70,7 @@ public class HashMapStore implements Store {
      *             {@inheritDoc}
      */
     @Override
-    public void put(final long address, final BigInteger value) {
+    public void put(final int address, final BigInteger value) {
         if (address < 0 || address > MAX_ADDRESS) {
             throw new IndexOutOfBoundsException("Address " + address
                     + " must be between " + 0 + " and " + MAX_ADDRESS);
@@ -92,7 +92,7 @@ public class HashMapStore implements Store {
      *             {@inheritDoc}
      */
     @Override
-    public BigInteger get(final long address) {
+    public BigInteger get(final int address) {
         if (address < 0 || address > MAX_ADDRESS) {
             throw new IndexOutOfBoundsException("Bad address: " + address);
         }

--- a/src/main/java/analyticalengine/components/Store.java
+++ b/src/main/java/analyticalengine/components/Store.java
@@ -37,7 +37,7 @@ public interface Store {
      * @throws IndexOutOfBoundsException
      *             if the address is negative or too large for the store.
      */
-    BigInteger get(long address);
+    BigInteger get(int address);
 
     /**
      * Stores {@code value} in the memory location specified by {@code address}
@@ -50,7 +50,7 @@ public interface Store {
      * @throws IndexOutOfBoundsException
      *             if the address is negative or too large for the store.
      */
-    void put(long address, BigInteger value);
+    void put(int address, BigInteger value);
 
     /**
      * Clears all values in the store.


### PR DESCRIPTION
*What problem does this solve?*
This commit replaces the use of `long` as the type of the index for the `Store` object with `int`.

*How does this affect the user?*
Any `Store` implementation must now use `int` addresses instead of `long` addresses.

*Why is this better than the alternative?*
This matches the Java requirements for array indices and makes it easier to provide alternate implementations of the `Store` interface.